### PR TITLE
Tag Docker Builds

### DIFF
--- a/.github/workflows/deploy_master.yml
+++ b/.github/workflows/deploy_master.yml
@@ -68,3 +68,4 @@ jobs:
           tags: |
             dangeroustech/streamdl:latest
             dangeroustech/streamdl:stable
+            dangeroustech/streamdl:${{ steps.changelog.outputs.tag }}

--- a/.github/workflows/deploy_master.yml
+++ b/.github/workflows/deploy_master.yml
@@ -33,16 +33,29 @@ jobs:
           load: true
           tags: dangeroustech/streamdl:latest
 
-      - name: Version
-        uses: go-semantic-release/action@v1
-        id: semrel
+      - name: Changelog
+        uses: TriPSs/conventional-changelog-action@v3
+        id: changelog
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          git-message: 'chore(release): {version} [skip ci]'
           force-bump-patch-version: true
           changelog-generator-opt: "emojis=true"
-          changelog-file: "CHANGELOG.md"
-          prepend: true
-          update-file: pyproject.toml
+          output-file: "CHANGELOG.md"
+          tag-prefix: 'v'
+          release-count: 0
+          version-file: pyproject.toml
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        id: release
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+        with:
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          release_name: ${{ steps.changelog.outputs.tag }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}
 
       - name: Dockerhub Push Stable
         id: dockerhub_stable_push

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -33,17 +33,6 @@ jobs:
           load: true
           tags: dangeroustech/streamdl:latest
 
-      - name: Version
-        uses: go-semantic-release/action@v1
-        id: semrel
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          force-bump-patch-version: true
-          changelog-generator-opt: "emojis=true"
-          changelog-file: "CHANGELOG.md"
-          prepend: true
-          update-file: pyproject.toml
-
       - name: Dockerhub Push Staging
         id: dockerhub_staging_push
         uses: docker/build-push-action@v2


### PR DESCRIPTION
Fixes #218 

Changes proposed in this pull request:

- add tag to dockerhub builds
- replace changelog/release action with one that should _actually_ write a changelog
- remove release action from staging branch (wouldn't have been running anyway)
