### PR TITLE
fix: remove unnecessary docker build

### DIFF
--- a/.github/workflows/deploy_master.yml
+++ b/.github/workflows/deploy_master.yml
@@ -24,16 +24,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Docker Build
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: Dockerfile.example
-          load: true
-          tags: dangeroustech/streamdl:latest
-    
-
       - name: Changelog
         uses: TriPSs/conventional-changelog-action@v3
         id: changelog


### PR DESCRIPTION
We're doing a docker build in test now to catch issues, and the build and test builds and runs the correct version as it's post changelog/release tagging