### PR TITLE
fix: build integration client image once per run

### DIFF
--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -6,6 +6,10 @@ set -euo pipefail
 # Usage: ./tests/integration/run.sh
 #
 # Requires: docker compose, ffprobe
+#
+# Env:
+#   INTEGRATION_FORCE_BUILD=1  Rebuild the client image on every start_client call
+#                              (default: build once, then recreate only)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPOSE_FILE="$SCRIPT_DIR/docker-compose.integration.yml"
@@ -50,6 +54,7 @@ CANDIDATE_CHANNELS=(
 
 HOOKS_DIR="$SCRIPT_DIR/hooks"
 LIVE_CHANNEL=""
+CLIENT_BUILT=0
 
 cleanup() {
   echo "--- Tearing down ---"
@@ -58,9 +63,15 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Rebuild and recreate the client without restarting the server.
+# Recreate the client without restarting the server. Build the image once per run
+# unless INTEGRATION_FORCE_BUILD=1 (config/mount changes still apply via recreate).
 start_client() {
-  $DC -f "$COMPOSE_FILE" up -d --build --force-recreate --no-deps client
+  local build_args=()
+  if [ "${INTEGRATION_FORCE_BUILD:-0}" = "1" ] || [ "$CLIENT_BUILT" -eq 0 ]; then
+    build_args=(--build)
+  fi
+  CLIENT_BUILT=1
+  $DC -f "$COMPOSE_FILE" up -d "${build_args[@]}" --force-recreate --no-deps client
 }
 
 assert_notice_after_wait() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #576

## Summary

Integration tests were rebuilding the Go client Docker image on every `start_client()` call (live → VOD → notice 6b → notice 6a). That added minutes per run and contributed to disk exhaustion during local validation.

## Changes

- `start_client()` passes `--build` only on the **first** call per run
- Subsequent phase transitions use `--force-recreate --no-deps` only (config/volume changes still apply)
- `INTEGRATION_FORCE_BUILD=1` restores rebuild-on-every-call behaviour when needed
- Documented env var in `run.sh` header

## Testing

- [x] `bash -n tests/integration/run.sh` (syntax)
- [ ] Full `./tests/integration/run.sh` — please run locally before merge (requires Docker + live Twitch)

## Notes

Server build is unchanged (single build at startup). Only client rebuild redundancy is addressed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-927bc4fa-7743-4031-bf1c-d706838e43d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-927bc4fa-7743-4031-bf1c-d706838e43d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved integration test startup behavior by reusing a previously built client image during repeated launches, reducing unnecessary rebuilds.
  * Added support for forcing a fresh client image build on every start when needed.
  * Clarified the script’s behavior so it’s easier to understand when builds are reused versus rebuilt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->