### PR TITLE
fix: shutdown drain can hang when downloadStream exits without response send

### DIFF
--- a/download_stream.go
+++ b/download_stream.go
@@ -85,7 +85,7 @@ func createDirWithUmask(path string) error {
 // It uses the provided initialURLs for the first FFmpeg attempt and resolves a fresh
 // URL on retries to avoid stale tokens.
 // It removes the user from the active list on exit and moves the finished file to moveLoc.
-func downloadStream(user string, site string, quality string, initialURLs StreamURLs, outLoc string, moveLoc string, subfolder bool, postScript string, control <-chan bool, response chan<- bool) {
+func downloadStream(user string, site string, quality string, initialURLs StreamURLs, outLoc string, moveLoc string, subfolder bool, postScript string, control <-chan bool) {
 	naturalFinish := make(chan error, 1)
 	sigint := make(chan bool)
 	t := time.Now().Format("2006-01-02_15-04-05")
@@ -302,7 +302,6 @@ func downloadStream(user string, site string, quality string, initialURLs Stream
 				log.Errorf("Error waiting for %s process to exit: %v", user, err)
 			}
 			time.Sleep(time.Second * 2)
-			response <- true
 			return
 		case err := <-naturalFinish:
 			if err != nil {
@@ -322,7 +321,6 @@ func downloadStream(user string, site string, quality string, initialURLs Stream
 						continue
 					case <-sigint:
 						log.Tracef("Abort received during backoff for %s", user)
-						response <- true
 						return
 					}
 				}

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestDownloadWgShutdownDrain verifies the shutdown pattern used for live downloads:
+// wait on a WaitGroup instead of counting channel receives. This guards against the
+// hang described in issue #583 where a snapshot of activeUsers could expect more
+// response signals than goroutines actually send.
+func TestDownloadWgShutdownDrain(t *testing.T) {
+	var wg sync.WaitGroup
+	waitDone := make(chan struct{})
+
+	wg.Add(2)
+	go func() {
+		wg.Wait()
+		close(waitDone)
+	}()
+
+	go func() {
+		defer wg.Done()
+		time.Sleep(10 * time.Millisecond)
+	}()
+	go func() {
+		defer wg.Done()
+		time.Sleep(20 * time.Millisecond)
+	}()
+
+	select {
+	case <-waitDone:
+	case <-time.After(time.Second):
+		t.Fatal("WaitGroup wait did not return after concurrent goroutine exits")
+	}
+}

--- a/streamdl.go
+++ b/streamdl.go
@@ -22,6 +22,7 @@ import (
 var (
 	activeUsers    = make(map[string]bool)
 	activeUsersMu  sync.RWMutex
+	downloadWg     sync.WaitGroup
 	vodWg          sync.WaitGroup
 	postScriptWg   sync.WaitGroup
 )
@@ -55,7 +56,6 @@ func main() {
 		config = parsed
 	}
 	control := make(chan bool)
-	response := make(chan bool)
 
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 	log.SetFormatter(&prefixed.TextFormatter{FullTimestamp: true})
@@ -202,7 +202,11 @@ func main() {
 								if probeResult.Warning != "" {
 									tickNotices.Warn(streamer.User, probeResult.Warning)
 								}
-								go downloadStream(streamer.User, site.Site, streamer.Quality, probeResult, *outLoc, *moveLoc, *subfolder, site.PostScript, control, response)
+								downloadWg.Add(1)
+								go func() {
+									defer downloadWg.Done()
+									downloadStream(streamer.User, site.Site, streamer.Quality, probeResult, *outLoc, *moveLoc, *subfolder, site.PostScript, control)
+								}()
 								break
 							}
 
@@ -238,13 +242,7 @@ func main() {
 			log.Tracef("Ticker Stopped")
 			log.Tracef("Closing Control Channel")
 			close(control)
-
-			activeUsersMu.RLock()
-			urlsLen := len(activeUsers)
-			activeUsersMu.RUnlock()
-			for i := 0; i < urlsLen; i++ {
-				<-response
-			}
+			downloadWg.Wait()
 			vodWg.Wait()
 			postScriptWg.Wait()
 			time.Sleep(time.Second * 3)

--- a/tests/integration/.gitignore
+++ b/tests/integration/.gitignore
@@ -1,2 +1,3 @@
 output/
 config/
+data/


### PR DESCRIPTION
## Summary
- Replace the shutdown `response` channel drain with a `downloadWg` WaitGroup, matching the existing `vodWg` / `postScriptWg` pattern
- Remove the unused `response` parameter and SIGINT-only sends from `downloadStream`
- Add a unit test documenting the WaitGroup shutdown pattern

Fixes #583

## Test plan
- [x] `go test ./...`
- [ ] Send SIGINT while multiple live downloads are active and confirm the process exits promptly
- [ ] Send SIGINT while one stream ends naturally at the same moment and confirm no hang


Made with [Cursor](https://cursor.com)