### PR TITLE
fix: avoid brittle OS package revision pins

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -11,7 +11,7 @@ RUN go get -v && \
 FROM golang:1.25.3-alpine AS client
 
 # Install su-exec and curl for running as non-root and health checks
-RUN apk add --no-cache su-exec=0.2-r3 curl=8.14.1-r2
+RUN apk add --no-cache su-exec curl
 
 WORKDIR /app
 

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -9,7 +9,9 @@ RUN which uv
 FROM python:3.13-slim-bookworm AS server
 
 # Install gosu and curl for running as non-root and health checks
-RUN apt-get update && apt-get install -y --no-install-recommends gosu=1.14-1+b10 curl=7.88.1-10+deb12u14 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gosu curl && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the Docker build failures caused by OS package revisions disappearing from mutable Alpine and Debian repositories.

Changes proposed in this pull request:

- Install Alpine `su-exec` and `curl` without exact repository revision pins
- Install Debian `gosu` and `curl` without exact repository revision pins
- Preserve the existing base images and runtime behavior
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f647a-72a1-7243-b099-b5d35a45d2d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f647a-72a1-7243-b099-b5d35a45d2d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

