### PR TITLE
ci: separate PR Docker builds from staging deployment

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -3,8 +3,6 @@ name: Dockerhub Build - Staging
 on:
   push:
     branches: [staging]
-  pull_request_target:
-    branches: [staging]
 
 permissions:
   contents: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,17 +49,11 @@ jobs:
         component: [client, server]
     steps:
       - uses: actions/checkout@v7
-      - name: Login to DockerHub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Docker Build and Push Unstable
-        id: docker_build_push_unstable
+      - name: Docker Build Test
+        id: docker_build_test
         uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.${{ matrix.component }}
           platforms: linux/amd64
-          push: true
-          tags: dangeroustech/streamdl:${{ matrix.component }}_unstable
+          push: false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Changes proposed in this pull request:

- Run the staging deployment workflow only after pushes to `staging`
- Keep prospective client and server image builds in the pull-request test workflow
- Stop PR checks from logging into DockerHub or publishing `_unstable` images

#587 has merged, and this branch now includes its Docker package fix so the prospective image builds can validate the resulting staging state.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f647a-72a1-7243-b099-b5d35a45d2d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f647a-72a1-7243-b099-b5d35a45d2d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

