### PR TITLE
chore(deps): update actions/setup-node to v7

### DIFF
--- a/.github/workflows/deploy_master.yml
+++ b/.github/workflows/deploy_master.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           check-latest: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Changes proposed in this pull request:

- Update `actions/setup-node` from v6 to v7 in the master deployment workflow
- Adopt the current Node.js 24-based action runtime and updated action dependencies
- Revalidate the update against current staging after the Docker and workflow fixes

All affected jobs run on GitHub-hosted runners, which satisfy setup-node v7's runner requirement. This supersedes stale Dependabot PR #586.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f647a-72a1-7243-b099-b5d35a45d2d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f647a-72a1-7243-b099-b5d35a45d2d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

