### PR TITLE
feat: parse FFmpeg progress for structured download status

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,7 @@ STREAMDL_GRPC_ADDR=server
 STREAMDL_GRPC_PORT=50051
 TICK_TIME=60
 LOG_LEVEL=INFO
+# Primary log destination: file (default), stdout, or both
+LOG_DEST=file
+# Optional override; default is /app/data/streamdl.log when LOG_DEST is file/both
+# LOG_FILE=/app/data/streamdl.log

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Why not get some use out of it? Archivists everywhere, rejoice!
 | `-batch`       | Time betwen URL checks (seconds): increase for rate limiting | `5`               |
 | `-subfolder`   | Add streams to a subfolder with the channel name             | `false`           |
 | `-log-level`   | Set logging level (debug, info, warn, error, etc)            | `info`            |
-| `-data`        | Directory for persistent data (VOD tracking database)        | `/app/data`       |
+| `-log-dest`    | Primary log destination: `file`, `stdout`, or `both`         | `file`            |
+| `-log-file`    | Log file path (used when `-log-dest` is `file` or `both`)    | `<data>/streamdl.log` |
+| `-data`        | Directory for persistent data (VOD tracking database + default log) | `/app/data`  |
 | `-vod-out`     | Output location for VOD downloads (defaults to `-out`)       | Same as `-out`    |
 | `-vod-move`    | Move location for completed VOD downloads (defaults to `-move`) | Same as `-move` |
 
@@ -68,12 +70,20 @@ When using Docker, be aware of the following:
 Example directory setup before launching:
 
 ```shell
-mkdir -p downloads/{,in}complete config
+mkdir -p downloads/{,in}complete config data
 ```
 
-Logs are piped to stdout by default so that `docker compose logs` works.
-_If you know what you're doing, you can change this value in `entrypoint.sh`._
-_Make sure to rebuild the container with `docker compose build` after editing this._
+### Logging
+
+StreamDL can send full application logs to a file, container stdout, or both:
+
+| `LOG_DEST` / `-log-dest` | Primary logs | Container stdout (`docker compose logs`) |
+| ------------------------ | ------------ | ---------------------------------------- |
+| `file` (default)         | `<data>/streamdl.log` | Active Downloads summary each tick only |
+| `stdout`                 | stdout       | Full logs (legacy-style)                 |
+| `both`                   | file + stdout | Full logs, and the same content in the log file |
+
+Override the file path with `LOG_FILE` / `-log-file` when using `file` or `both`. Mount `/app/data` (see `docker-compose.yml.example`) so the default log file and VOD database persist on the host.
 
 ### Bare Metal
 
@@ -204,6 +214,8 @@ Some of these are also available as flags to the `streamdl` command, this is a #
 | `STREAMDL_GRPC_PORT` | The port number for the gRPC server                                                                               | `50051`  |
 | `TICK_TIME`          | Time interval (in seconds) between stream checks                                                                  | `60`     |
 | `LOG_LEVEL`          | Logging verbosity level (DEBUG, INFO, WARN, ERROR)                                                                | `INFO`   |
+| `LOG_DEST`           | Primary log destination: `file`, `stdout`, or `both`                                                              | `file`   |
+| `LOG_FILE`           | Log file path when `LOG_DEST` is `file` or `both`                                                                 | `/app/data/streamdl.log` |
 | `UMASK`              | File permission mask in octal format (e.g. "022"). Controls default permissions for created files and directories | `022`    |
 | `PUID`               | User ID that will own the files/directories created by the container (Docker only)                                | `1000`   |
 | `PGID`               | Group ID that will own the files/directories created by the container (Docker only)                               | `1000`   |

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -17,5 +17,6 @@ services:
       - ./downloads/incomplete:/app/dl # in-progress downloads location
       - ./downloads/complete:/app/out # completed downloads location
       - ./config:/app/config # config folder - using a folder allows host updates without cycling the container
+      - ./data:/app/data # VOD DB + default streamdl.log when LOG_DEST=file/both
     depends_on:
       - server

--- a/download_stream.go
+++ b/download_stream.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -89,6 +88,12 @@ func downloadStream(user string, site string, quality string, initialURLs Stream
 	naturalFinish := make(chan error, 1)
 	sigint := make(chan bool)
 	t := time.Now().Format("2006-01-02_15-04-05")
+	progressKey := progressKeyLive(user)
+	downloadProgress.Start(progressKey, ProgressMeta{
+		Channel: user,
+		Kind:    DownloadKindLive,
+	})
+	ffLogs := newFFmpegLogWriter(progressKey, downloadProgress)
 
 	// Always ensure the user is removed from the active list when this goroutine exits
 	defer func() {
@@ -96,6 +101,7 @@ func downloadStream(user string, site string, quality string, initialURLs Stream
 		delete(activeUsers, user)
 		activeUsersMu.Unlock()
 		tickNotices.ClearChannel(user)
+		downloadProgress.End(progressKey)
 		log.Debugf("Removed %s from active list", user)
 	}()
 
@@ -184,13 +190,12 @@ func downloadStream(user string, site string, quality string, initialURLs Stream
 		}
 		url := streamURLs.Video
 
-		buf := &bytes.Buffer{}
 		cmd := fluentffmpeg.
 			NewCommand("").
 			InputPath(url).
 			OutputFormat("mp4").
 			OutputPath(outPath).
-			OutputLogs(buf).
+			OutputLogs(ffLogs).
 			Build()
 
 		// Inject network hygiene before the FFmpeg input ("-i") argument.
@@ -308,7 +313,7 @@ func downloadStream(user string, site string, quality string, initialURLs Stream
 			if err != nil {
 				// Emit a compact tail of FFmpeg logs to aid diagnosis
 				log.Warnf("FFmpeg failed for %s: %v", user, err)
-				ffLog := tailString(buf.String(), 50)
+				ffLog := tailString(ffLogs.String(), 50)
 				if ffLog != "" {
 					log.Warnf("FFmpeg log tail for %s:\n%s", user, sanitizeLog(ffLog))
 				}
@@ -542,6 +547,20 @@ func downloadVOD(user string, vod VodResult, url string, outLoc string, moveLoc 
 
 	naturalFinish := make(chan error, 1)
 	sigint := make(chan bool)
+	progressKey := progressKeyVOD(user, vod.ID)
+	var totalDur time.Duration
+	if vod.DurationSeconds > 0 {
+		totalDur = time.Duration(vod.DurationSeconds) * time.Second
+	}
+	downloadProgress.Start(progressKey, ProgressMeta{
+		Channel:       user,
+		Kind:          DownloadKindVOD,
+		VodID:         vod.ID,
+		Title:         vod.Title,
+		TotalDuration: totalDur,
+	})
+	ffLogs := newFFmpegLogWriter(progressKey, downloadProgress)
+	defer downloadProgress.End(progressKey)
 
 	// Always ensure base directories have correct permissions first
 	if err := createDirWithUmask(outLoc); err != nil {
@@ -593,13 +612,12 @@ func downloadVOD(user string, vod VodResult, url string, outLoc string, moveLoc 
 		}
 	}()
 
-	buf := &bytes.Buffer{}
 	cmd := fluentffmpeg.
 		NewCommand("").
 		InputPath(url).
 		OutputFormat("mp4").
 		OutputPath(outPath).
-		OutputLogs(buf).
+		OutputLogs(ffLogs).
 		Build()
 
 	// Prefer stream copy for VODs to avoid re-encoding
@@ -647,7 +665,7 @@ func downloadVOD(user string, vod VodResult, url string, outLoc string, moveLoc 
 	case err := <-naturalFinish:
 		if err != nil {
 			log.Warnf("FFmpeg failed for VOD %s: %v", vod.ID, err)
-			ffLog := tailString(buf.String(), 50)
+			ffLog := tailString(ffLogs.String(), 50)
 			if ffLog != "" {
 				log.Debugf("FFmpeg log tail for VOD %s:\n%s", vod.ID, sanitizeLog(ffLog))
 			}

--- a/logging.go
+++ b/logging.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+	prefixed "github.com/x-cray/logrus-prefixed-formatter"
+)
+
+// LogDest controls where primary application logs are written.
+type LogDest string
+
+const (
+	LogDestFile   LogDest = "file"
+	LogDestStdout LogDest = "stdout"
+	LogDestBoth   LogDest = "both"
+)
+
+// LoggingConfig holds the active logging sinks for cleanup and console summary.
+type LoggingConfig struct {
+	Dest     LogDest
+	FilePath string
+	file     *os.File
+}
+
+var (
+	consoleSummaryMu sync.Mutex
+	// consoleSummary, when non-nil, receives tick Active Downloads lines on
+	// stdout while primary logs go only to a file (dest=file).
+	consoleSummary io.Writer
+)
+
+func parseLogDest(s string) (LogDest, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "file":
+		return LogDestFile, nil
+	case "stdout", "console", "container":
+		return LogDestStdout, nil
+	case "both", "all":
+		return LogDestBoth, nil
+	default:
+		return "", fmt.Errorf("invalid log destination %q (want file, stdout, or both)", s)
+	}
+}
+
+func envOr(name, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv(name)); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// setupLogging configures logrus output and the optional stdout tick summary sink.
+//
+// Destinations:
+//   - file:   full logs → log file; container stdout gets Active Downloads each tick
+//   - stdout: full logs → stdout (legacy / docker-compose logs as primary)
+//   - both:   full logs → log file and stdout
+//
+// When dest is file or both and filePath is empty, it defaults to
+// <dataDir>/streamdl.log.
+func setupLogging(levelStr, destStr, filePath, dataDir string) (*LoggingConfig, error) {
+	dest, err := parseLogDest(destStr)
+	if err != nil {
+		return nil, err
+	}
+
+	ll, err := log.ParseLevel(levelStr)
+	if err != nil {
+		ll = log.InfoLevel
+	}
+
+	filePath = strings.TrimSpace(filePath)
+	needsFile := dest == LogDestFile || dest == LogDestBoth
+	if needsFile && filePath == "" {
+		if strings.TrimSpace(dataDir) == "" {
+			dataDir = "/app/data"
+		}
+		filePath = filepath.Join(dataDir, "streamdl.log")
+	}
+
+	log.SetFormatter(&prefixed.TextFormatter{FullTimestamp: true})
+	log.SetLevel(ll)
+
+	cfg := &LoggingConfig{Dest: dest, FilePath: filePath}
+	consoleSummary = nil
+
+	var writers []io.Writer
+	switch dest {
+	case LogDestStdout:
+		writers = append(writers, os.Stdout)
+	case LogDestFile, LogDestBoth:
+		if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+			return nil, fmt.Errorf("create log directory: %w", err)
+		}
+		f, err := os.OpenFile(filePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			return nil, fmt.Errorf("open log file %s: %w", filePath, err)
+		}
+		cfg.file = f
+		writers = append(writers, f)
+		if dest == LogDestBoth {
+			writers = append(writers, os.Stdout)
+		} else {
+			// Primary logs are file-only; expose a dedicated stdout summary sink.
+			consoleSummary = os.Stdout
+		}
+	}
+
+	switch len(writers) {
+	case 0:
+		log.SetOutput(os.Stdout)
+	case 1:
+		log.SetOutput(writers[0])
+	default:
+		log.SetOutput(io.MultiWriter(writers...))
+	}
+
+	return cfg, nil
+}
+
+// Close releases the log file handle, if any.
+func (c *LoggingConfig) Close() {
+	if c == nil || c.file == nil {
+		return
+	}
+	_ = c.file.Close()
+	c.file = nil
+}
+
+// writeConsoleDownloadSummary writes the Active Downloads block to stdout when
+// primary logs are file-only. No-op for stdout/both (logrus already covers it).
+func writeConsoleDownloadSummary(store *progressStore) {
+	if consoleSummary == nil {
+		return
+	}
+	snap := store.Snapshot()
+	var b strings.Builder
+	b.WriteString("Active Downloads:\n")
+	if len(snap) == 0 {
+		b.WriteString("  (none)\n")
+	} else {
+		for _, p := range snap {
+			fmt.Fprintf(&b, "  %s\n", formatDownloadProgress(p))
+		}
+	}
+	consoleSummaryMu.Lock()
+	defer consoleSummaryMu.Unlock()
+	_, _ = io.WriteString(consoleSummary, b.String())
+}

--- a/logging_test.go
+++ b/logging_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func TestParseLogDest(t *testing.T) {
+	cases := map[string]LogDest{
+		"":          LogDestFile,
+		"file":      LogDestFile,
+		"FILE":      LogDestFile,
+		"stdout":    LogDestStdout,
+		"console":   LogDestStdout,
+		"container": LogDestStdout,
+		"both":      LogDestBoth,
+		"all":       LogDestBoth,
+	}
+	for in, want := range cases {
+		got, err := parseLogDest(in)
+		if err != nil {
+			t.Fatalf("parseLogDest(%q): %v", in, err)
+		}
+		if got != want {
+			t.Fatalf("parseLogDest(%q)=%q want %q", in, got, want)
+		}
+	}
+	if _, err := parseLogDest("nope"); err == nil {
+		t.Fatal("expected error for invalid dest")
+	}
+}
+
+func TestSetupLogging_FileDefaultPathAndConsoleSummary(t *testing.T) {
+	dir := t.TempDir()
+	origOut := log.StandardLogger().Out
+	origSummary := consoleSummary
+	t.Cleanup(func() {
+		log.SetOutput(origOut)
+		consoleSummary = origSummary
+	})
+
+	cfg, err := setupLogging("info", "file", "", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cfg.Close()
+
+	wantPath := filepath.Join(dir, "streamdl.log")
+	if cfg.FilePath != wantPath {
+		t.Fatalf("path=%q want %q", cfg.FilePath, wantPath)
+	}
+	if consoleSummary == nil {
+		t.Fatal("expected console summary writer for file dest")
+	}
+
+	log.Info("hello-file-only")
+	_ = cfg.file.Sync()
+	body, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "hello-file-only") {
+		t.Fatalf("log file missing entry: %s", body)
+	}
+}
+
+func TestSetupLogging_StdoutNoConsoleSummary(t *testing.T) {
+	origOut := log.StandardLogger().Out
+	origSummary := consoleSummary
+	t.Cleanup(func() {
+		log.SetOutput(origOut)
+		consoleSummary = origSummary
+	})
+
+	cfg, err := setupLogging("debug", "stdout", "", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cfg.Close()
+	if consoleSummary != nil {
+		t.Fatal("stdout dest should not set console summary sink")
+	}
+	if cfg.FilePath != "" {
+		t.Fatalf("stdout dest should not invent a file path, got %q", cfg.FilePath)
+	}
+}
+
+func TestSetupLogging_BothWritesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "custom.log")
+	origOut := log.StandardLogger().Out
+	origSummary := consoleSummary
+	t.Cleanup(func() {
+		log.SetOutput(origOut)
+		consoleSummary = origSummary
+	})
+
+	cfg, err := setupLogging("info", "both", path, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cfg.Close()
+	if consoleSummary != nil {
+		t.Fatal("both dest should rely on logrus for stdout, not summary sink")
+	}
+	log.Info("hello-both")
+	_ = cfg.file.Sync()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "hello-both") {
+		t.Fatalf("missing log: %s", body)
+	}
+}
+
+func TestWriteConsoleDownloadSummary(t *testing.T) {
+	var buf bytes.Buffer
+	origSummary := consoleSummary
+	consoleSummary = &buf
+	t.Cleanup(func() { consoleSummary = origSummary })
+
+	store := newProgressStore()
+	writeConsoleDownloadSummary(store)
+	if !strings.Contains(buf.String(), "Active Downloads:") || !strings.Contains(buf.String(), "(none)") {
+		t.Fatalf("empty summary: %q", buf.String())
+	}
+
+	buf.Reset()
+	key := progressKeyLive("alice")
+	store.Start(key, ProgressMeta{Channel: "alice", Kind: DownloadKindLive})
+	store.Update(key, ffmpegProgressSample{SizeBytes: 2048, Duration: 0, Speed: 1, Valid: true})
+	writeConsoleDownloadSummary(store)
+	out := buf.String()
+	if !strings.Contains(out, "[alice] live") || strings.Contains(out, "(none)") {
+		t.Fatalf("unexpected summary: %q", out)
+	}
+}

--- a/progress.go
+++ b/progress.go
@@ -1,0 +1,466 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// DownloadKind identifies whether a download is a live stream or a VOD.
+type DownloadKind string
+
+const (
+	DownloadKindLive DownloadKind = "live"
+	DownloadKindVOD  DownloadKind = "vod"
+)
+
+// DownloadProgress is a point-in-time snapshot of an active FFmpeg download.
+type DownloadProgress struct {
+	Key             string
+	Channel         string
+	Kind            DownloadKind
+	VodID           string
+	Title           string
+	SizeBytes       int64
+	Duration        time.Duration
+	TotalDuration   time.Duration // known for some VODs; 0 if unknown
+	Speed           float64       // realtime multiplier; 0 if unknown / N/A
+	BitrateKbps     float64
+	Percent         *float64
+	ETA             *time.Duration
+	StartedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+// ProgressMeta describes a download when it is registered.
+type ProgressMeta struct {
+	Channel       string
+	Kind          DownloadKind
+	VodID         string
+	Title         string
+	TotalDuration time.Duration
+}
+
+type progressStore struct {
+	mu    sync.RWMutex
+	items map[string]*DownloadProgress
+}
+
+func newProgressStore() *progressStore {
+	return &progressStore{items: make(map[string]*DownloadProgress)}
+}
+
+// downloadProgress is the process-wide active-download registry; tests may replace it.
+var downloadProgress = newProgressStore()
+
+func progressKeyLive(channel string) string {
+	return "live:" + channel
+}
+
+func progressKeyVOD(channel, vodID string) string {
+	return "vod:" + channel + ":" + vodID
+}
+
+// Start registers (or resets) an active download entry.
+func (s *progressStore) Start(key string, meta ProgressMeta) {
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items[key] = &DownloadProgress{
+		Key:           key,
+		Channel:       meta.Channel,
+		Kind:          meta.Kind,
+		VodID:         meta.VodID,
+		Title:         meta.Title,
+		TotalDuration: meta.TotalDuration,
+		StartedAt:     now,
+		UpdatedAt:     now,
+	}
+}
+
+// End removes an active download entry.
+func (s *progressStore) End(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.items, key)
+}
+
+// Update applies a parsed FFmpeg progress sample to an active download.
+func (s *progressStore) Update(key string, sample ffmpegProgressSample) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, ok := s.items[key]
+	if !ok {
+		return
+	}
+	if sample.SizeBytes > 0 {
+		p.SizeBytes = sample.SizeBytes
+	}
+	if sample.Duration > 0 {
+		p.Duration = sample.Duration
+	}
+	if sample.Speed > 0 {
+		p.Speed = sample.Speed
+	}
+	if sample.BitrateKbps > 0 {
+		p.BitrateKbps = sample.BitrateKbps
+	}
+	p.UpdatedAt = time.Now()
+	p.Percent, p.ETA = derivePercentETA(p.Duration, p.TotalDuration, p.Speed)
+}
+
+// Get returns a copy of one download's progress, if present.
+func (s *progressStore) Get(key string) (DownloadProgress, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	p, ok := s.items[key]
+	if !ok {
+		return DownloadProgress{}, false
+	}
+	return *p, true
+}
+
+// Snapshot returns a stable, sorted copy of all active downloads.
+func (s *progressStore) Snapshot() []DownloadProgress {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]DownloadProgress, 0, len(s.items))
+	for _, p := range s.items {
+		out = append(out, *p)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Channel != out[j].Channel {
+			return out[i].Channel < out[j].Channel
+		}
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		return out[i].VodID < out[j].VodID
+	})
+	return out
+}
+
+func derivePercentETA(elapsed, total time.Duration, speed float64) (*float64, *time.Duration) {
+	if total <= 0 || elapsed <= 0 {
+		return nil, nil
+	}
+	pct := (float64(elapsed) / float64(total)) * 100
+	if pct < 0 {
+		pct = 0
+	}
+	if pct > 100 {
+		pct = 100
+	}
+	percent := pct
+
+	var eta *time.Duration
+	if speed > 0 && elapsed < total {
+		remaining := time.Duration(float64(total-elapsed) / speed)
+		eta = &remaining
+	}
+	return &percent, eta
+}
+
+// ffmpegProgressSample is one parsed progress update from FFmpeg output.
+type ffmpegProgressSample struct {
+	SizeBytes   int64
+	Duration    time.Duration
+	Speed       float64
+	BitrateKbps float64
+	Valid       bool
+}
+
+var (
+	reSize    = regexp.MustCompile(`(?:^|\s)size=\s*([0-9.]+)\s*([KkMmGg]?i?[Bb])`)
+	reTime    = regexp.MustCompile(`(?:^|\s)time=\s*(\d{1,2}):(\d{2}):(\d{2}(?:\.\d+)?)`)
+	reSpeed   = regexp.MustCompile(`(?:^|\s)speed=\s*([0-9.]+)x`)
+	reBitrate = regexp.MustCompile(`(?:^|\s)bitrate=\s*([0-9.]+)kbits/s`)
+	// -progress key=value form
+	reKV = regexp.MustCompile(`^([a-zA-Z0-9_]+)=(.+)$`)
+)
+
+// parseFFmpegProgressLine extracts progress fields from a single FFmpeg status line
+// or a -progress key=value line. Returns Valid=false when the line is not progress.
+func parseFFmpegProgressLine(line string) ffmpegProgressSample {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return ffmpegProgressSample{}
+	}
+
+	// -progress machine-readable lines
+	if m := reKV.FindStringSubmatch(line); m != nil && !strings.Contains(line, " ") {
+		sample := ffmpegProgressSample{}
+		switch m[1] {
+		case "total_size":
+			if n, err := strconv.ParseInt(strings.TrimSpace(m[2]), 10, 64); err == nil && n > 0 {
+				sample.SizeBytes = n
+				sample.Valid = true
+			}
+		case "out_time_ms":
+			// FFmpeg out_time_ms is actually microseconds despite the name.
+			if n, err := strconv.ParseInt(strings.TrimSpace(m[2]), 10, 64); err == nil && n > 0 {
+				sample.Duration = time.Duration(n) * time.Microsecond
+				sample.Valid = true
+			}
+		case "out_time_us":
+			if n, err := strconv.ParseInt(strings.TrimSpace(m[2]), 10, 64); err == nil && n > 0 {
+				sample.Duration = time.Duration(n) * time.Microsecond
+				sample.Valid = true
+			}
+		case "out_time":
+			if d, ok := parseFFmpegClock(strings.TrimSpace(m[2])); ok {
+				sample.Duration = d
+				sample.Valid = true
+			}
+		case "speed":
+			val := strings.TrimSuffix(strings.TrimSpace(m[2]), "x")
+			if n, err := strconv.ParseFloat(val, 64); err == nil && n > 0 {
+				sample.Speed = n
+				sample.Valid = true
+			}
+		case "bitrate":
+			val := strings.TrimSpace(m[2])
+			val = strings.TrimSuffix(val, "kbits/s")
+			if n, err := strconv.ParseFloat(val, 64); err == nil && n > 0 {
+				sample.BitrateKbps = n
+				sample.Valid = true
+			}
+		}
+		return sample
+	}
+
+	// Human status line: frame=... size=... time=... bitrate=... speed=...
+	if !strings.Contains(line, "size=") && !strings.Contains(line, "time=") && !strings.Contains(line, "speed=") {
+		return ffmpegProgressSample{}
+	}
+
+	sample := ffmpegProgressSample{}
+	if m := reSize.FindStringSubmatch(line); m != nil {
+		if n, err := parseFFmpegSize(m[1], m[2]); err == nil {
+			sample.SizeBytes = n
+			sample.Valid = true
+		}
+	}
+	if m := reTime.FindStringSubmatch(line); m != nil {
+		hours, _ := strconv.Atoi(m[1])
+		mins, _ := strconv.Atoi(m[2])
+		secs, _ := strconv.ParseFloat(m[3], 64)
+		sample.Duration = time.Duration(hours)*time.Hour +
+			time.Duration(mins)*time.Minute +
+			time.Duration(secs*float64(time.Second))
+		sample.Valid = true
+	}
+	if m := reSpeed.FindStringSubmatch(line); m != nil {
+		if n, err := strconv.ParseFloat(m[1], 64); err == nil {
+			sample.Speed = n
+			sample.Valid = true
+		}
+	}
+	if m := reBitrate.FindStringSubmatch(line); m != nil {
+		if n, err := strconv.ParseFloat(m[1], 64); err == nil {
+			sample.BitrateKbps = n
+			sample.Valid = true
+		}
+	}
+	return sample
+}
+
+func parseFFmpegClock(v string) (time.Duration, bool) {
+	if v == "" || strings.EqualFold(v, "N/A") {
+		return 0, false
+	}
+	parts := strings.Split(v, ":")
+	if len(parts) != 3 {
+		return 0, false
+	}
+	hours, errH := strconv.Atoi(parts[0])
+	mins, errM := strconv.Atoi(parts[1])
+	secs, errS := strconv.ParseFloat(parts[2], 64)
+	if errH != nil || errM != nil || errS != nil {
+		return 0, false
+	}
+	return time.Duration(hours)*time.Hour +
+		time.Duration(mins)*time.Minute +
+		time.Duration(secs*float64(time.Second)), true
+}
+
+func parseFFmpegSize(value, unit string) (int64, error) {
+	n, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, err
+	}
+	mult := 1.0
+	switch strings.ToLower(unit) {
+	case "b":
+		mult = 1
+	case "kb", "kib":
+		mult = 1024
+	case "mb", "mib":
+		mult = 1024 * 1024
+	case "gb", "gib":
+		mult = 1024 * 1024 * 1024
+	default:
+		return 0, fmt.Errorf("unknown size unit %q", unit)
+	}
+	return int64(n * mult), nil
+}
+
+// ffmpegLogWriter tees FFmpeg stderr into a tail buffer while parsing progress lines.
+type ffmpegLogWriter struct {
+	key           string
+	store         *progressStore
+	mu            sync.Mutex
+	buf           bytes.Buffer
+	partial       []byte
+	maxBytes      int
+	lastDebugAt   time.Time
+	debugInterval time.Duration
+}
+
+func newFFmpegLogWriter(key string, store *progressStore) *ffmpegLogWriter {
+	return &ffmpegLogWriter{
+		key:           key,
+		store:         store,
+		maxBytes:      64 * 1024,
+		debugInterval: 10 * time.Second,
+	}
+}
+
+func (w *ffmpegLogWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if _, err := w.buf.Write(p); err != nil {
+		return 0, err
+	}
+	if w.buf.Len() > w.maxBytes {
+		trimmed := w.buf.Bytes()[w.buf.Len()-w.maxBytes:]
+		w.buf.Reset()
+		w.buf.Write(trimmed)
+	}
+
+	data := append(w.partial, p...)
+	w.partial = w.partial[:0]
+
+	start := 0
+	for i := 0; i < len(data); i++ {
+		if data[i] == '\n' || data[i] == '\r' {
+			if i > start {
+				w.handleLine(string(data[start:i]))
+			}
+			start = i + 1
+		}
+	}
+	if start < len(data) {
+		w.partial = append(w.partial[:0], data[start:]...)
+	}
+	return len(p), nil
+}
+
+func (w *ffmpegLogWriter) handleLine(line string) {
+	sample := parseFFmpegProgressLine(line)
+	if !sample.Valid {
+		return
+	}
+	w.store.Update(w.key, sample)
+
+	now := time.Now()
+	if !w.lastDebugAt.IsZero() && now.Sub(w.lastDebugAt) < w.debugInterval {
+		return
+	}
+	w.lastDebugAt = now
+	if p, ok := w.store.Get(w.key); ok {
+		log.Debugf("download progress %s", formatDownloadProgress(p))
+	}
+}
+
+// String returns the accumulated log buffer (for failure tails).
+func (w *ffmpegLogWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+func formatDownloadProgress(p DownloadProgress) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "[%s] %s", p.Channel, p.Kind)
+	if p.Kind == DownloadKindVOD {
+		label := p.Title
+		if label == "" {
+			label = p.VodID
+		}
+		if label != "" {
+			fmt.Fprintf(&b, " %q", label)
+		}
+	}
+	if p.Percent != nil {
+		fmt.Fprintf(&b, " %.1f%%", *p.Percent)
+	}
+	if p.SizeBytes > 0 {
+		fmt.Fprintf(&b, " size=%s", formatBytes(p.SizeBytes))
+	}
+	if p.Duration > 0 {
+		fmt.Fprintf(&b, " time=%s", formatDurationShort(p.Duration))
+	}
+	if p.Speed > 0 {
+		fmt.Fprintf(&b, " speed=%.2fx", p.Speed)
+	}
+	if p.ETA != nil {
+		fmt.Fprintf(&b, " eta=%s", formatDurationShort(*p.ETA))
+	}
+	return b.String()
+}
+
+func formatBytes(n int64) string {
+	const (
+		kib = 1024
+		mib = 1024 * kib
+		gib = 1024 * mib
+	)
+	switch {
+	case n >= gib:
+		return fmt.Sprintf("%.2fGiB", float64(n)/float64(gib))
+	case n >= mib:
+		return fmt.Sprintf("%.1fMiB", float64(n)/float64(mib))
+	case n >= kib:
+		return fmt.Sprintf("%.1fKiB", float64(n)/float64(kib))
+	default:
+		return fmt.Sprintf("%dB", n)
+	}
+}
+
+func formatDurationShort(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	d = d.Round(time.Second)
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+	s := int(d.Seconds()) % 60
+	if h > 0 {
+		return fmt.Sprintf("%dh%02dm%02ds", h, m, s)
+	}
+	if m > 0 {
+		return fmt.Sprintf("%dm%02ds", m, s)
+	}
+	return fmt.Sprintf("%ds", s)
+}
+
+// logActiveDownloadSummary writes an INFO summary of in-flight downloads for the tick.
+func logActiveDownloadSummary(store *progressStore) {
+	snap := store.Snapshot()
+	if len(snap) == 0 {
+		return
+	}
+	log.Info("Active Downloads:")
+	for _, p := range snap {
+		log.Infof("  %s", formatDownloadProgress(p))
+	}
+}

--- a/progress.go
+++ b/progress.go
@@ -453,14 +453,18 @@ func formatDurationShort(d time.Duration) string {
 	return fmt.Sprintf("%ds", s)
 }
 
-// logActiveDownloadSummary writes an INFO summary of in-flight downloads for the tick.
+// logActiveDownloadSummary writes an INFO summary of in-flight downloads for the
+// tick into the primary log sink, and mirrors a plain Active Downloads block to
+// stdout when logging is file-primary (see setupLogging).
 func logActiveDownloadSummary(store *progressStore) {
 	snap := store.Snapshot()
 	if len(snap) == 0 {
-		return
+		log.Debug("Active Downloads: (none)")
+	} else {
+		log.Info("Active Downloads:")
+		for _, p := range snap {
+			log.Infof("  %s", formatDownloadProgress(p))
+		}
 	}
-	log.Info("Active Downloads:")
-	for _, p := range snap {
-		log.Infof("  %s", formatDownloadProgress(p))
-	}
+	writeConsoleDownloadSummary(store)
 }

--- a/progress_test.go
+++ b/progress_test.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseFFmpegProgressLine_StatusLine(t *testing.T) {
+	line := "frame= 1234 fps= 30 q=28.0 size=    1024kB time=00:00:41.20 bitrate= 203.4kbits/s speed=1.01x"
+	sample := parseFFmpegProgressLine(line)
+	if !sample.Valid {
+		t.Fatal("expected valid sample")
+	}
+	if sample.SizeBytes != 1024*1024 {
+		t.Fatalf("size=%d want %d", sample.SizeBytes, 1024*1024)
+	}
+	wantDur := 41*time.Second + 200*time.Millisecond
+	if sample.Duration != wantDur {
+		t.Fatalf("duration=%v want %v", sample.Duration, wantDur)
+	}
+	if sample.Speed < 1.009 || sample.Speed > 1.011 {
+		t.Fatalf("speed=%v want ~1.01", sample.Speed)
+	}
+	if sample.BitrateKbps < 203.3 || sample.BitrateKbps > 203.5 {
+		t.Fatalf("bitrate=%v want ~203.4", sample.BitrateKbps)
+	}
+}
+
+func TestParseFFmpegProgressLine_CarriageReturnStyle(t *testing.T) {
+	line := "frame=  100 fps=0.0 q=-1.0 size=     256kB time=00:00:03.20 bitrate= 655.4kbits/s speed=6.4x"
+	sample := parseFFmpegProgressLine(line)
+	if !sample.Valid {
+		t.Fatal("expected valid sample")
+	}
+	if sample.SizeBytes != 256*1024 {
+		t.Fatalf("size=%d", sample.SizeBytes)
+	}
+	if sample.Duration != 3*time.Second+200*time.Millisecond {
+		t.Fatalf("duration=%v", sample.Duration)
+	}
+}
+
+func TestParseFFmpegProgressLine_NAIgnored(t *testing.T) {
+	line := "frame=    0 fps=0.0 q=0.0 size=N/A time=00:00:00.00 bitrate=N/A speed=N/A"
+	sample := parseFFmpegProgressLine(line)
+	// time=00:00:00.00 still parses as Valid with zero-ish duration; size/speed N/A skipped
+	if sample.SizeBytes != 0 {
+		t.Fatalf("size should be 0 for N/A, got %d", sample.SizeBytes)
+	}
+	if sample.Speed != 0 {
+		t.Fatalf("speed should be 0 for N/A, got %v", sample.Speed)
+	}
+}
+
+func TestParseFFmpegProgressLine_NonProgress(t *testing.T) {
+	sample := parseFFmpegProgressLine("Input #0, hls, from 'https://example.com/index.m3u8':")
+	if sample.Valid {
+		t.Fatal("non-progress line should be invalid")
+	}
+}
+
+func TestParseFFmpegProgressLine_ProgressKV(t *testing.T) {
+	cases := []struct {
+		line string
+		check func(*testing.T, ffmpegProgressSample)
+	}{
+		{
+			line: "total_size=1048576",
+			check: func(t *testing.T, s ffmpegProgressSample) {
+				if !s.Valid || s.SizeBytes != 1048576 {
+					t.Fatalf("got %+v", s)
+				}
+			},
+		},
+		{
+			line: "out_time_ms=41200000",
+			check: func(t *testing.T, s ffmpegProgressSample) {
+				if !s.Valid || s.Duration != 41*time.Second+200*time.Millisecond {
+					t.Fatalf("got %+v", s)
+				}
+			},
+		},
+		{
+			line: "speed=0.95x",
+			check: func(t *testing.T, s ffmpegProgressSample) {
+				if !s.Valid || s.Speed < 0.949 || s.Speed > 0.951 {
+					t.Fatalf("got %+v", s)
+				}
+			},
+		},
+		{
+			line: "progress=continue",
+			check: func(t *testing.T, s ffmpegProgressSample) {
+				if s.Valid {
+					t.Fatalf("progress marker should not be a sample, got %+v", s)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.line, func(t *testing.T) {
+			tc.check(t, parseFFmpegProgressLine(tc.line))
+		})
+	}
+}
+
+func TestProgressStore_UpdatePercentETA(t *testing.T) {
+	store := newProgressStore()
+	key := progressKeyVOD("alice", "v123")
+	store.Start(key, ProgressMeta{
+		Channel:       "alice",
+		Kind:          DownloadKindVOD,
+		VodID:         "v123",
+		Title:         "Cool Stream",
+		TotalDuration: 100 * time.Second,
+	})
+	store.Update(key, ffmpegProgressSample{
+		SizeBytes: 10 * 1024 * 1024,
+		Duration:  40 * time.Second,
+		Speed:     2.0,
+		Valid:     true,
+	})
+
+	p, ok := store.Get(key)
+	if !ok {
+		t.Fatal("expected progress entry")
+	}
+	if p.Percent == nil || *p.Percent < 39.9 || *p.Percent > 40.1 {
+		t.Fatalf("percent=%v want ~40", p.Percent)
+	}
+	if p.ETA == nil || *p.ETA != 30*time.Second {
+		t.Fatalf("eta=%v want 30s", p.ETA)
+	}
+
+	store.End(key)
+	if _, ok := store.Get(key); ok {
+		t.Fatal("expected entry removed")
+	}
+}
+
+func TestProgressStore_SnapshotSorted(t *testing.T) {
+	store := newProgressStore()
+	store.Start(progressKeyLive("zack"), ProgressMeta{Channel: "zack", Kind: DownloadKindLive})
+	store.Start(progressKeyLive("alice"), ProgressMeta{Channel: "alice", Kind: DownloadKindLive})
+	store.Start(progressKeyVOD("alice", "9"), ProgressMeta{Channel: "alice", Kind: DownloadKindVOD, VodID: "9"})
+
+	snap := store.Snapshot()
+	if len(snap) != 3 {
+		t.Fatalf("len=%d", len(snap))
+	}
+	if snap[0].Channel != "alice" || snap[0].Kind != DownloadKindLive {
+		t.Fatalf("first=%+v", snap[0])
+	}
+	if snap[1].Channel != "alice" || snap[1].Kind != DownloadKindVOD {
+		t.Fatalf("second=%+v", snap[1])
+	}
+	if snap[2].Channel != "zack" {
+		t.Fatalf("third=%+v", snap[2])
+	}
+}
+
+func TestFFmpegLogWriter_ParsesCRSeparatedLines(t *testing.T) {
+	store := newProgressStore()
+	key := progressKeyLive("day9tv")
+	store.Start(key, ProgressMeta{Channel: "day9tv", Kind: DownloadKindLive})
+	w := newFFmpegLogWriter(key, store)
+	w.debugInterval = time.Hour // silence debug noise in test
+
+	payload := "frame= 10 fps=30 size=   128kB time=00:00:01.00 bitrate=100.0kbits/s speed=1.00x\r" +
+		"frame= 20 fps=30 size=   256kB time=00:00:02.00 bitrate=100.0kbits/s speed=1.00x\r"
+	if _, err := w.Write([]byte(payload)); err != nil {
+		t.Fatal(err)
+	}
+
+	p, ok := store.Get(key)
+	if !ok {
+		t.Fatal("missing progress")
+	}
+	if p.SizeBytes != 256*1024 {
+		t.Fatalf("size=%d want 256KiB", p.SizeBytes)
+	}
+	if p.Duration != 2*time.Second {
+		t.Fatalf("duration=%v", p.Duration)
+	}
+	if !strings.Contains(w.String(), "size=") {
+		t.Fatalf("writer should retain log tail, got %q", w.String())
+	}
+}
+
+func TestFormatDownloadProgress(t *testing.T) {
+	pct := 45.0
+	eta := 24 * time.Minute
+	s := formatDownloadProgress(DownloadProgress{
+		Channel:   "bob",
+		Kind:      DownloadKindVOD,
+		Title:     "Highlights",
+		SizeBytes: 800 * 1024 * 1024,
+		Duration:  20 * time.Minute,
+		Speed:     0.95,
+		Percent:   &pct,
+		ETA:       &eta,
+	})
+	for _, want := range []string{"[bob]", "vod", "Highlights", "45.0%", "size=", "time=", "speed=0.95x", "eta="} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("format missing %q in %q", want, s)
+		}
+	}
+}
+
+func TestLogActiveDownloadSummary(t *testing.T) {
+	store := newProgressStore()
+	store.Start(progressKeyLive("alice"), ProgressMeta{Channel: "alice", Kind: DownloadKindLive})
+	store.Update(progressKeyLive("alice"), ffmpegProgressSample{
+		SizeBytes: 1024,
+		Duration:  time.Minute,
+		Speed:     1,
+		Valid:     true,
+	})
+
+	out := captureLogs(func() {
+		logActiveDownloadSummary(store)
+	})
+	if !strings.Contains(out, "Active Downloads:") {
+		t.Fatalf("missing header: %s", out)
+	}
+	if !strings.Contains(out, "[alice] live") {
+		t.Fatalf("missing entry: %s", out)
+	}
+}

--- a/progress_test.go
+++ b/progress_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 	"time"
@@ -218,6 +219,11 @@ func TestLogActiveDownloadSummary(t *testing.T) {
 		Valid:     true,
 	})
 
+	var console bytes.Buffer
+	origSummary := consoleSummary
+	consoleSummary = &console
+	t.Cleanup(func() { consoleSummary = origSummary })
+
 	out := captureLogs(func() {
 		logActiveDownloadSummary(store)
 	})
@@ -226,5 +232,8 @@ func TestLogActiveDownloadSummary(t *testing.T) {
 	}
 	if !strings.Contains(out, "[alice] live") {
 		t.Fatalf("missing entry: %s", out)
+	}
+	if !strings.Contains(console.String(), "[alice] live") {
+		t.Fatalf("console summary missing entry: %q", console.String())
 	}
 }

--- a/streamdl.go
+++ b/streamdl.go
@@ -238,6 +238,7 @@ func main() {
 		activeUsersMu.RUnlock()
 		sort.Strings(users)
 		log.Infof("Currently Live Users: %v", strings.Join(users, ", "))
+		logActiveDownloadSummary(downloadProgress)
 		tickNotices.Flush(*tickTime)
 
 		select {

--- a/streamdl.go
+++ b/streamdl.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 )
 
 var (
@@ -35,7 +34,9 @@ func main() {
 	tickTime := flag.Int("time", 60, "Time to tick (seconds)")
 	batchTime := flag.Int("batch", 5, "Time betwen URL checks (seconds): increase for rate limiting")
 	subfolder := flag.Bool("subfolder", false, "Add streams to a subfolder with the channel name")
-	logLevel := flag.String("log-level", "info", "Log level (trace, debug, info, warn, error, fatal, panic)")
+	logLevel := flag.String("log-level", envOr("LOG_LEVEL", "info"), "Log level (trace, debug, info, warn, error, fatal, panic)")
+	logDest := flag.String("log-dest", envOr("LOG_DEST", "file"), "Where to write primary logs: file, stdout, or both")
+	logFile := flag.String("log-file", os.Getenv("LOG_FILE"), "Log file path (default: <data>/streamdl.log when log-dest is file/both)")
 	dataDir := flag.String("data", "/app/data", "Directory for persistent data (VOD tracking database)")
 	vodOutLoc := flag.String("vod-out", "", "Output location for VOD downloads (defaults to -out)")
 	vodMoveLoc := flag.String("vod-move", "", "Move location for completed VOD downloads (defaults to -move)")
@@ -49,6 +50,13 @@ func main() {
 		vodMoveLoc = moveLoc
 	}
 
+	loggingCfg, logErr := setupLogging(*logLevel, *logDest, *logFile, *dataDir)
+	if logErr != nil {
+		fmt.Fprintf(os.Stderr, "Logging setup failed: %v\n", logErr)
+		os.Exit(1)
+	}
+	defer loggingCfg.Close()
+
 	var ticker = time.NewTicker(time.Second * time.Duration(*tickTime))
 	var config []Config
 	parsed, confErr := parseConfig(readConfig(*confLoc))
@@ -58,16 +66,11 @@ func main() {
 	control := make(chan bool)
 
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
-	log.SetFormatter(&prefixed.TextFormatter{FullTimestamp: true})
-
-	ll, err := log.ParseLevel(*logLevel)
-	if err != nil {
-		log.Warnf("Invalid log level '%s', defaulting to info", *logLevel)
-		log.SetLevel(log.InfoLevel)
+	if loggingCfg.Dest == LogDestFile || loggingCfg.Dest == LogDestBoth {
+		log.Infof("Starting StreamDL... (log file: %s, dest: %s)", loggingCfg.FilePath, loggingCfg.Dest)
 	} else {
-		log.SetLevel(ll)
+		log.Infof("Starting StreamDL... (dest: %s)", loggingCfg.Dest)
 	}
-	log.Infof("Starting StreamDL...")
 
 	// VOD database is lazily initialized on first VOD tick
 	var vodDB *VodDB

--- a/streamdl_client_entrypoint.sh
+++ b/streamdl_client_entrypoint.sh
@@ -1,3 +1,27 @@
 #!/bin/sh
 
-./streamdl -config /app/config/config.yml -out /app/dl -move /app/out -time "${TICK_TIME:-60}" -log-level "${LOG_LEVEL:-info}"
+set -eu
+
+LOG_LEVEL="${LOG_LEVEL:-info}"
+LOG_DEST="${LOG_DEST:-file}"
+
+if [ -n "${LOG_FILE:-}" ]; then
+  exec ./streamdl \
+    -config /app/config/config.yml \
+    -out /app/dl \
+    -move /app/out \
+    -time "${TICK_TIME:-60}" \
+    -log-level "${LOG_LEVEL}" \
+    -log-dest "${LOG_DEST}" \
+    -log-file "${LOG_FILE}" \
+    -data /app/data
+fi
+
+exec ./streamdl \
+  -config /app/config/config.yml \
+  -out /app/dl \
+  -move /app/out \
+  -time "${TICK_TIME:-60}" \
+  -log-level "${LOG_LEVEL}" \
+  -log-dest "${LOG_DEST}" \
+  -data /app/data


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #577

Changes proposed in this pull request:

- Parse FFmpeg stderr progress lines (`size=` / `time=` / `speed=` / `bitrate=`) and `-progress` key=value fields during live and VOD downloads
- Keep active download state in an in-memory registry (`downloadProgress.Snapshot()` for future TUI #552)
- Log individual updates at DEBUG (throttled to ~10s); print an INFO “Active Downloads” summary each tick
- Derive percent + ETA for VODs when `DurationSeconds` is known
- **Configurable logging destinations** (`-log-dest` / `LOG_DEST`: `file` | `stdout` | `both`)
  - **Default `file`**: full logs → `<data>/streamdl.log`; container stdout is only the Active Downloads block each tick
  - `stdout`: full logs to container stdout (legacy-style)
  - `both`: full logs to file and stdout
- Override path with `-log-file` / `LOG_FILE`; example compose mounts `./data:/app/data`

**Not merged** — left as draft for local testing before landing on staging.

### Local test tips
```bash
# default: file primary + stdout summary only
./streamdl -config config.yml -log-dest file -data ./data -log-level info

# legacy: everything in docker/container logs
./streamdl -config config.yml -log-dest stdout

# both
./streamdl -config config.yml -log-dest both -log-file ./data/streamdl.log
```

### Out of scope
- Bubbletea TUI (#552)
- Log rotation
- Push notifications / webhooks

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f740a-ed5f-744f-8391-6bdda177e1cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f740a-ed5f-744f-8391-6bdda177e1cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable logging destinations: file, standard output, or both.
  * Added optional custom log-file configuration through CLI flags and environment variables.
  * Added active download progress summaries, including status, duration, speed, and estimated completion.
  * Added live and VOD progress tracking.

* **Documentation**
  * Updated usage, environment variable, Docker, and logging documentation.

* **Chores**
  * Updated the Docker Compose example to persist application data and log files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->