### PR TITLE
docs: opt-in Intel /dev/dri passthrough for Quick Sync hosts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ LOG_LEVEL=INFO
 LOG_DEST=file
 # Optional override; default is /app/data/streamdl.log when LOG_DEST is file/both
 # LOG_FILE=/app/data/streamdl.log
+
+# Intel /dev/dri passthrough is configured in docker-compose (devices/group_add),
+# not via env. See README "Intel Quick Sync / /dev/dri passthrough".
+# Default client FFmpeg is static and has no QSV yet (#611).

--- a/README.md
+++ b/README.md
@@ -73,6 +73,39 @@ Example directory setup before launching:
 mkdir -p downloads/{,in}complete config data
 ```
 
+### Intel Quick Sync / `/dev/dri` passthrough
+
+StreamDL can optionally receive the host Intel graphics device so hardware encode/decode is possible **when FFmpeg supports it**.
+
+**Important limitations today**
+
+- The default client image uses `mwader/static-ffmpeg`, which does **not** include Quick Sync (QSV) or VAAPI. Passing `/dev/dri` into that image alone will not accelerate encodes.
+- Most StreamDL downloads remux with stream copy (`-c copy` for VODs; optional via `FFMPEG_STREAM_COPY` for live). Remuxing does not use the GPU. Quick Sync only helps when something **re-encodes** (in-process via `FFMPEG_EXTRA_*`, or a `post_script` transcoder).
+- A QSV/VAAPI-capable client image is tracked in #611; first-class hwaccel presets in #612.
+
+**Enable device access (opt-in)**
+
+1. Confirm the host has a render node, e.g. `ls -l /dev/dri`.
+2. Note the `video` / `render` group IDs (they vary by distro):
+   ```shell
+   getent group video render
+   stat -c '%g' /dev/dri/renderD128
+   ```
+3. In `docker-compose.yml`, uncomment the client `devices:` / `group_add:` block from `docker-compose.yml.example` and replace the example GIDs with yours.
+4. Keep `PUID`/`PGID` as usual for download file ownership; `group_add` is separate and only grants DRM device access.
+
+Example (GIDs illustrative only):
+
+```yaml
+devices:
+  - /dev/dri:/dev/dri
+group_add:
+  - "44"   # video
+  - "992"  # render
+```
+
+On TrueNAS / Kubernetes-style apps, map the same device and supplemental groups through the UI or runtime equivalent of Docker `devices` + `group_add`.
+
 ### Logging
 
 StreamDL can send full application logs to a file, container stdout, or both:

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -18,5 +18,15 @@ services:
       - ./downloads/complete:/app/out # completed downloads location
       - ./config:/app/config # config folder - using a folder allows host updates without cycling the container
       - ./data:/app/data # VOD DB + default streamdl.log when LOG_DEST=file/both
+    # Optional: Intel Quick Sync / VAAPI device passthrough (see README).
+    # Uncomment only on hosts with /dev/dri. GIDs are host-specific — run
+    # `stat -c '%g' /dev/dri/renderD128` and `getent group video render`.
+    # NOTE: The default client image ships static FFmpeg without QSV/VAAPI.
+    # Device access alone is not enough until a QSV-capable image is available (#611).
+    # devices:
+    #   - /dev/dri:/dev/dri
+    # group_add:
+    #   - "44"    # video  — replace with your host video GID
+    #   - "992"   # render — replace with your host render GID
     depends_on:
       - server


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #610

Changes proposed in this pull request:

- Comment in an opt-in `devices:` / `group_add:` block on the client service in `docker-compose.yml.example` for `/dev/dri`
- README section covering host render-node checks, GID discovery, PUID vs `group_add`, TrueNAS/K8s note, and the static-FFmpeg limitation
- Pointer in `.env.example` that passthrough is compose-side, not an env var

Part of epic #452. Follow-ups: #611 (QSV-capable image), #612 (hwaccel presets).

No runtime/Dockerfile behavior change — default installs remain unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f740a-ed5f-744f-8391-6bdda177e1cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f740a-ed5f-744f-8391-6bdda177e1cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

